### PR TITLE
For #11530: fix ensure_text bug

### DIFF
--- a/hooks/tk-multi-loader2/basic/scene_actions.py
+++ b/hooks/tk-multi-loader2/basic/scene_actions.py
@@ -121,7 +121,7 @@ class PremiereActions(HookBaseClass):
             self.execute_action(name, params, sg_publish_data)
 
     def _get_path_from_sg_publish_data(self, sg_publish_data):
-        return self.get_publish_path(six.ensure_text(sg_publish_data))
+        return six.ensure_text(self.get_publish_path(sg_publish_data))
 
     def execute_action(self, name, params, sg_publish_data):
         """


### PR DESCRIPTION
The `ensure_text` should not be on the publish_data dictionary, but rather on what `get_publish_path` returns.