### PR TITLE
12123 import as new clips

### DIFF
--- a/hooks/tk-multi-breakdown2/basic/scene_operation.py
+++ b/hooks/tk-multi-breakdown2/basic/scene_operation.py
@@ -131,15 +131,16 @@ class BreakdownSceneOperations(HookBaseClass):
             import_in_bin_template = self.parent.get_template("import_in_bin_template")
             if import_in_bin_template:
                 import_bin_path = import_in_bin_template.apply_fields(sg_data)
-                self.logger.info("Resolved import bin path to %s from %s with %s" % (import_bin_path, import_in_bin_template, sg_data))
-                parts = [p for p in import_bin_path.split("/") if p]  # Skip leading, ending and consecutive /
-                if not parts:
-                    self.logger.error("Invalid import bin path %s" % import_bin_path)
-                current_bin = current_project.ensure_bin(parts[0])
-                for part in parts[1:]:
-                    current_bin = current_bin.ensure_bin(part)
+                self.logger.debug("Resolved import bin path to %s from %s with %s" % (import_bin_path, import_in_bin_template, sg_data))
+                current_bin = current_project.ensure_bins_for_path(import_bin_path)
                 current_bin.create_clip_from_media(path)
             else:
+                # None is returned by get_template if the template can't be found, check if the setting was
+                # set to report the problem
+                template_setting = self.parent.get_setting("import_in_bin_template")
+                if template_setting:
+                    self.logger.error("Invalid template setting %s" % template_setting)
+                    return False
                 # For now just update the path in place.
                 clip = current_project.get_clip_by_id(node_id)
                 if not clip:

--- a/hooks/tk-multi-breakdown2/basic/scene_operation.py
+++ b/hooks/tk-multi-breakdown2/basic/scene_operation.py
@@ -148,7 +148,7 @@ class BreakdownSceneOperations(HookBaseClass):
                     return False
                 clip.media_path = path
         except Exception as e:
-            self.logger.exception("Unable to update %s" % item)
+            self.logger.exception("Unable to update %s: %s" % (item, e))
             return False
         self.logger.info("%s updated with %s" % (clip, path))
         return path

--- a/python/tk_premiere/premiere.py
+++ b/python/tk_premiere/premiere.py
@@ -179,6 +179,34 @@ class PremiereProject(PremiereItem):
                 return clip
         return None
 
+    def get_bin_by_name(self, name):
+        """
+        Return the bin with the given name from the project root, if any.
+
+        :returns: A :class:`PremiereBin` or ``None``.
+        """
+        return PremiereBin(self._item.rootItem).get_bin_by_name(name)
+
+    def create_bin(self, path):
+        """
+        Create a bin with the current name under the project root bin.
+
+        :param str name: The bin name to create.
+        :returns: A :class:`PremiereBin`.
+        """
+        top_bin = self._item.rootItem
+        return PremiereBin(top_bin.createBin(name))
+
+    def ensure_bin(self, name):
+        """
+        Ensure that a bin with the given name exists under the project root bin.
+
+        :param str name: The name of the bin.
+        :returns: A :class:`PremiereBin`.
+        """
+        top_bin = self._item.rootItem
+        return PremiereBin(top_bin).ensure_bin(name)
+
     def save(self, path=None):
         """
         Save this project in place or to the given path.
@@ -366,6 +394,40 @@ class PremiereBin(PremiereItem):
             # Sequences are clips as well.
             if child.type == ItemType.CLIP and not child.isSequence():
                 yield PremiereClip(child)
+
+    def get_bin_by_name(self, name):
+        """
+        Return the bin with the given name in this bin, if any.
+
+        :returns: A :class:`PremiereBin` or ``None``.
+        """
+        for i in range(self._item.children.numItems):
+            child = self._item.children[i]
+            if child and child.type == ItemType.BIN:
+                if child.name == name:
+                    return PremiereBin(child)
+        return None
+
+    def create_bin(self, name):
+        """
+        Create a bin with the current name under this bin.
+
+        :param str name: The name of the new bin.
+        :returns: A :class:`PremiereBin`.
+        """
+        return PremiereBin(self._item.createBin(name))
+
+    def ensure_bin(self, name):
+        """
+        Ensure that a bin with the given name exists under this bin.
+
+        :param str name: The name of the bin.
+        :returns: A :class:`PremiereBin`.
+        """
+        bin = self.get_bin_by_name(name)
+        if not bin:
+            bin = self.create_bin(name)
+        return bin
 
 
 class PremiereClip(PremiereItem):

--- a/python/tk_premiere/premiere.py
+++ b/python/tk_premiere/premiere.py
@@ -214,6 +214,22 @@ class PremiereProject(PremiereItem):
         top_bin = self._item.rootItem
         return PremiereBin(top_bin).ensure_bin(name)
 
+    def ensure_bins_for_path(self, path):
+        """
+        Ensure that bins exists for the given path.
+
+        :param str path: A bins path, with / as separators.
+        :returns: A :class:`PremiereBin`.
+        :raises ValueError: For invalid paths.
+        """
+        parts = [p for p in path.split("/") if p]  # Skip leading, ending and consecutive /
+        if not parts:
+            raise ValueError("Invalid import bin path %s" % path)
+        current_bin = self.ensure_bin(parts[0])
+        for part in parts[1:]:
+            current_bin = current_bin.ensure_bin(part)
+        return current_bin
+
     def save(self, path=None):
         """
         Save this project in place or to the given path.


### PR DESCRIPTION
Added some helpers to manipulate bins and import media in a new clip.
Added a new `import_in_bin_template` setting to not update clips in place in breakdown hook.
Leverage what was added to the engine.