### PR TITLE
11730 meta data

### DIFF
--- a/python/tk_premiere/premiere.py
+++ b/python/tk_premiere/premiere.py
@@ -128,6 +128,7 @@ class PremiereItem(object):
         self.item.setProjectMetadata(repl, [property])
         return self.get_meta_data(property)
 
+
 class PremiereProject(PremiereItem):
     """
     A class to handle Premiere projects.

--- a/python/tk_premiere/premiere.py
+++ b/python/tk_premiere/premiere.py
@@ -79,7 +79,7 @@ class PremiereItem(object):
         :returns: The meta data value or ``None``.
         """
         meta_data = self.item.getProjectMetadata()
-        # We get something like, with only for properties which have been set:
+        # We get something like this, with tags only for properties which have been set:
         # <?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?>
         # <x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="Adobe XMP Core 7.1-c000 79.b0f8be9, 2021/12/08-19:11:22        ">
         #    <rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
@@ -303,7 +303,7 @@ class PremiereProject(PremiereItem):
         Add a property with the given name to the meta data schema.
 
         .. note:: It is not possible to retrieve the meta data schema so the
-                  property is blinded added to the schema. Conflicts with
+                  property is blindly added to the schema. Conflicts with
                   existing properties do not cause errors, but their display
                   name or type is not changed if differents.
 

--- a/python/tk_premiere/premiere.py
+++ b/python/tk_premiere/premiere.py
@@ -314,7 +314,7 @@ class PremiereProject(PremiereItem):
         .. note:: It is not possible to retrieve the meta data schema so the
                   property is blindly added to the schema. Conflicts with
                   existing properties do not cause errors, but their display
-                  name or type is not changed if differents.
+                  name or type is not changed if different.
 
         :param str name: The name for the property, which acts as its indentifier.
         :param str display_name: The display name for the property, which will be displayed in UIs.

--- a/python/tk_premiere/premiere.py
+++ b/python/tk_premiere/premiere.py
@@ -117,14 +117,23 @@ class PremiereItem(object):
         :returns: The value which was actually set.
         """
         meta_data = self.item.getProjectMetadata()
-        # Since we pass the name of the property to set, we can just replace any property entry in
-        # the meta data string with what we want to set.
+        # Check if the property is present in the meta data and replace its value
         repl = re.sub(
-            r"<premierePrivateProjectMetaData:[^<]+>(.*)</premierePrivateProjectMetaData:.*>",
+            r"<premierePrivateProjectMetaData:%s>(.*)</premierePrivateProjectMetaData:%s>" % (property, property),
             r"<premierePrivateProjectMetaData:%s>%s</premierePrivateProjectMetaData:%s>" % (property, value, property),
             meta_data,
-            1
         )
+        if repl == meta_data:
+            # If we didn't find the property, add it to the meta data.
+            # Since we pass the name of the property to set, we can just replace any property entry in
+            # the meta data string with what we want to set.
+            repl = re.sub(
+                r"<premierePrivateProjectMetaData:[^<]+>(.*)</premierePrivateProjectMetaData:.*>",
+                r"<premierePrivateProjectMetaData:%s>%s</premierePrivateProjectMetaData:%s>" % (property, value, property),
+                meta_data,
+                1
+            )
+        # https://ppro-scripting.docsforadobe.dev/item/projectitem.html#projectitem-setprojectmetadata
         self.item.setProjectMetadata(repl, [property])
         return self.get_meta_data(property)
 


### PR DESCRIPTION
Added the ability to manipulate meta data saved with the Premiere project.

Introduced `get_meta_data`, `set_meta_data` and `add_meta_data_property` from what is available from the underlying API.

These changes do not affect so called "XMP meta data" (everything is xmp) which are saved on the files themselves.